### PR TITLE
Closing AsyncGraphDatabase.driver properly

### DIFF
--- a/knitwork/fragment.py
+++ b/knitwork/fragment.py
@@ -63,7 +63,7 @@ def fragment(
         )
 
     # close graph connection
-    close_adriver()
+    asyncio.run(close_adriver())
     
     # filter results
     for smiles, v in results.items():

--- a/knitwork/fragment.py
+++ b/knitwork/fragment.py
@@ -61,9 +61,6 @@ def fragment(
         results = asyncio.run(
             fragment_tasks(smiles_list, progress, timeout, (t1, t2, t3))
         )
-
-    # close graph connection
-    asyncio.run(close_adriver())
     
     # filter results
     for smiles, v in results.items():
@@ -154,6 +151,9 @@ async def fragment_tasks(smiles_list, progress, timeout, tasks):
     ]
 
     results = await asyncio.gather(*tasks)
+
+    # close graph connection
+    await close_adriver()
 
     return {
         smiles: {"subnodes": subnodes, "synthons": synthons, "r_groups": r_groups}

--- a/knitwork/fragment.py
+++ b/knitwork/fragment.py
@@ -63,7 +63,7 @@ def fragment(
         )
 
     # close graph connection
-    await close_adriver()
+    close_adriver()
     
     # filter results
     for smiles, v in results.items():

--- a/knitwork/fragment.py
+++ b/knitwork/fragment.py
@@ -63,7 +63,7 @@ def fragment(
         )
 
     # close graph connection
-    close_adriver()
+    await close_adriver()
     
     # filter results
     for smiles, v in results.items():

--- a/knitwork/query.py
+++ b/knitwork/query.py
@@ -82,7 +82,7 @@ def close_driver():
 async def close_adriver():
     global _adriver
     if _adriver is not None:
-        _adriver.close()
+        await _adriver.close()
         _adriver = None
 
 

--- a/knitwork/query.py
+++ b/knitwork/query.py
@@ -79,7 +79,7 @@ def close_driver():
         _driver = None
 
 
-def close_adriver():
+async def close_adriver():
     global _adriver
     if _adriver is not None:
         _adriver.close()


### PR DESCRIPTION
Fixing `RuntimeWarning: coroutine 'close_adriver' was never awaited close_adriver()` warning message due to poorly closing  AsyncGraphDatabase.driver.